### PR TITLE
Add main subroutine redirection functions

### DIFF
--- a/GPUtils.pm
+++ b/GPUtils.pm
@@ -155,18 +155,15 @@ sub GP_RedirectMainFn ($$;$$) {
         $main::data{redirectedMainFnDev}{$func} = $dev
           if ( main::IsDevice($dev) );
 
-        my $type = main::IsDevice($dev) ? main::GetType($dev) : undef;
-        if ( $type && $modules{$type}{DefFn} =~ /^(.+)::[^:]+$/ ) {
-            $type = $1;
-        }
         main::Log3 undef, 3,
-          (
-            $type
-            ? "[$type] $dev: "
-            : 'INFO: '
+            '['
+          . ( caller(1) )[3] . '] '
+          . (
+            main::IsDevice($dev)
+            ? "$dev: "
+            : ''
           )
-          . "Main subroutine $func() was redirected to use subroutine $fnew()"
-          . ( $pkg ne 'main' ? " by FHEM module $pkg" : '' ) . "."
+          . "Main subroutine $func() was redirected to use subroutine $fnew()."
           . " Original subroutine is still available as $fren().";
     }
 
@@ -189,15 +186,13 @@ sub GP_RestoreMainFn {
           && main::IsDevice( $main::data{redirectedMainFnDev}{$func} )
           ? $main::data{redirectedMainFnDev}{$func}
           : undef;
-        my $type = $dev ? main::GetType($dev) : undef;
-        if ( $type && $modules{$type}{DefFn} =~ /^(.+)::[^:]+$/ ) {
-            $type = $1;
-        }
         main::Log3 undef, 3,
-          (
-            $type
-            ? "[$type] $dev: "
-            : 'INFO: '
+            '['
+          . ( caller(1) )[3] . '] '
+          . (
+            $dev
+            ? "$dev: "
+            : ''
           )
           . "Original main subroutine $func() was restored and unlinked from "
           . $main::data{redirectedMainFn}{$func};

--- a/GPUtils.pm
+++ b/GPUtils.pm
@@ -116,6 +116,11 @@ sub GP_RedirectMainFn ($$;$$) {
             "ERROR: Main subroutine $func() cannot be redirected"
           . ' because it does not exist';
     }
+    elsif ( !defined( *{$fnew} ) ) {
+        $@ =
+            "ERROR: Main subroutine $func() cannot be redirected"
+          . " because target subroutine $fnew() does not exist";
+    }
     elsif (defined( $main::data{redirectedMainFn} )
         && defined( $main::data{redirectedMainFn}{$func} )
         && $main::data{redirectedMainFn}{$func} ne $fnew )

--- a/GPUtils.pm
+++ b/GPUtils.pm
@@ -34,7 +34,7 @@ use Exporter qw( import );
 use strict;
 use warnings;
 
-our %EXPORT_TAGS = (all => [qw(GP_Define GP_Catch GP_ForallClients GP_Import GP_Export)]);
+our %EXPORT_TAGS = (all => [qw(GP_Define GP_Catch GP_ForallClients GP_Import GP_Export GP_RedirectMainFn GP_RestoreMainFn GP_IsRedirectedFn)]);
 Exporter::export_ok_tags('all');
 
 #add FHEM/lib to @INC if it's not allready included. Should rather be in fhem.pl than here though...
@@ -99,6 +99,150 @@ sub GP_Export(@)
     foreach (@_) {
         *{ $main . $_ } = *{ $pkg . '::' . $_ };
     }
+}
+
+sub GP_RedirectMainFn ($$;$$) {
+    my ( $func, $fnew, $fren, $dev ) = @_;
+    my $pkg = caller(0);
+    $func = 'main::' . $func unless ( $func =~ /^main::/ );
+    $fnew = $pkg . '::'      unless ( $fnew =~ /::/ );
+    if ( !$fren && $func =~ /::([^:]+)$/ ) {
+        $fren = 'main::Main_' . $1;
+    }
+
+    no strict qw/refs/;
+    if ( !defined( *{$func} ) ) {
+        $@ =
+            "ERROR: Main subroutine $func() cannot be redirected"
+          . ' because it does not exist';
+    }
+    elsif (defined( $main::data{redirectedMainFn} )
+        && defined( $main::data{redirectedMainFn}{$func} )
+        && $main::data{redirectedMainFn}{$func} ne $fnew )
+    {
+        $@ =
+            "ERROR: Cannot redirect subroutine $func()"
+          . ' because it already links to '
+          . $main::data{redirectedMainFn}{$func} . '()';
+    }
+    elsif (defined( $main::data{renamedMainFn} )
+        && defined( $main::data{renamedMainFn}{$func} )
+        && $main::data{renamedMainFn}{$func} ne $fren )
+    {
+        $@ =
+            "ERROR: Main subroutine $func() can not be renamed to $fren()"
+          . ' because it was already renamed to subroutine '
+          . $main::data{renamedMainFn}{$func}
+          . '() by '
+          . $main::data{redirectedMainFn}{$func} . '()';
+    }
+    return 0 if ($@);
+
+    # only rename once
+    unless ( defined( $main::data{renamedMainFn} )
+        && $main::data{renamedMainFn}{$func} )
+    {
+        *{$fren} = *{$func};
+        $main::data{renamedMainFn}{$func} = $fren;
+    }
+
+    # only link once
+    unless ( defined( $main::data{redirectedMainFn} )
+        && $main::data{redirectedMainFn}{$func} )
+    {
+        *{$func} = *{$fnew};
+        $main::data{redirectedMainFn}{$func}    = $fnew;
+        $main::data{redirectedMainFnDev}{$func} = $dev
+          if ( main::IsDevice($dev) );
+
+        my $type = main::IsDevice($dev) ? main::GetType($dev) : undef;
+        if ( $type && $modules{$type}{DefFn} =~ /^(.+)::[^:]+$/ ) {
+            $type = $1;
+        }
+        main::Log3 undef, 3,
+          (
+            $type
+            ? "[$type] $dev: "
+            : 'INFO: '
+          )
+          . "Main subroutine $func() was redirected to use subroutine $fnew()"
+          . ( $pkg ne 'main' ? " by FHEM module $pkg" : '' ) . "."
+          . " Original subroutine is still available as $fren().";
+    }
+
+    return $fren;
+}
+
+sub GP_RestoreMainFn {
+    my ($func) = @_;
+    $func = 'main::' . $func unless ( $func =~ /^main::/ );
+    no strict qw/refs/;
+    return 0 unless ( defined( *{$func} ) );
+    if (   defined( $main::data{renamedMainFn} )
+        && defined( $main::data{renamedMainFn}{$func} ) )
+    {
+        *{$func} = *{ $main::data{renamedMainFn}{$func} };
+
+        my $dev =
+             defined( $main::data{redirectedMainFnDev} )
+          && defined( $main::data{redirectedMainFnDev}{$func} )
+          && main::IsDevice( $main::data{redirectedMainFnDev}{$func} )
+          ? $main::data{redirectedMainFnDev}{$func}
+          : undef;
+        my $type = $dev ? main::GetType($dev) : undef;
+        if ( $type && $modules{$type}{DefFn} =~ /^(.+)::[^:]+$/ ) {
+            $type = $1;
+        }
+        main::Log3 undef, 3,
+          (
+            $type
+            ? "[$type] $dev: "
+            : 'INFO: '
+          )
+          . "Original main subroutine $func() was restored and unlinked from "
+          . $main::data{redirectedMainFn}{$func};
+
+        delete $main::data{redirectedMainFn}{$func};
+        delete $main::data{redirectedMainFnDev}{$func};
+        delete $main::data{renamedMainFn}{$func};
+        delete $main::data{redirectedMainFn}
+          unless ( defined( $main::data{redirectedMainFn} ) );
+        delete $main::data{redirectedMainFnDev}
+          unless ( defined( $main::data{redirectedMainFnDev} ) );
+        delete $main::data{renamedMainFn}
+          unless ( defined( $main::data{renamedMainFn} ) );
+    }
+    if (   defined( $main::data{redirectedMainFn} )
+        && defined( $main::data{redirectedMainFn}{$func} ) )
+    {
+        $@ = "Failed to restore main function $func()";
+        main::Log3 undef, 3, "ERROR: " . $@;
+        return 0;
+    }
+    else {
+    }
+    return $func;
+}
+
+sub GP_IsRedirectedFn($) {
+    my ($func) = @_;
+    $func = 'main::' . $func unless ( $func =~ /^main::/ );
+    no strict qw/refs/;
+    return undef unless ( defined( *{$func} ) );
+    return wantarray
+      ? (
+        $main::data{redirectedMainFn}{$func},
+        (
+            defined( $main::data{renamedMainFn} )
+              && defined( $main::data{renamedMainFn}{$func} )
+            ? $main::data{renamedMainFn}{$func}
+            : undef
+        )
+      )
+      : 1
+      if ( defined( $main::data{redirectedMainFn} )
+        && defined( $main::data{redirectedMainFn}{$func} ) );
+    return 0;
 }
 
 1;


### PR DESCRIPTION
These new functions will allow to temporarily redirect existing routines in main context to another subroutine. The new subroutine must accept the same parameters and return output that is compatible with the original main subroutine.